### PR TITLE
Recognize at-large as state

### DIFF
--- a/data/ap-to-csv
+++ b/data/ap-to-csv
@@ -67,6 +67,10 @@ if (files.length > 1) {
   doResultsFile(files[0], function () {})
 }
 
+function isState (ru) {
+  return ru.level === 'state' || ru.level === 'at-large'
+}
+
 var statesWritten = []
 function doResultsFile (file, done) {
   fs.createReadStream(file)
@@ -83,7 +87,11 @@ function doResultsFile (file, done) {
         if (districtNumber.length === 1) { districtNumber = '0' + districtNumber }
         ru.districtId = states[ru.statePostal].fipsCode + '' + districtNumber
       }
-
+      if (isState(ru)) {
+        // normalize state; some say `at-large`
+        ru.level = 'state'
+        ru.fipsCode = states[statePostal].fipsCode
+      }
       processReportingUnit(ru)
     })
   })


### PR DESCRIPTION
Normalize "at-large" as "state"

@mileswwatkins @anandthakker in the 2012 historical presidential data, Nebraska and Maine state-level reporting units had their `level` listed as "at-large" instead of "state". Just noticed this an hour ago when those states weren't getting filled in. This corrects that for the sake of the historical geojson files.

@mileswwatkins do you know why these states would be labeled 'at-large', and will that also be the case in 2016 from AP data?
